### PR TITLE
Keep artifact version inline with release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,4 +117,4 @@ publishing {
 sourceCompatibility = "1.7"
 targetCompatibility = "1.7"
 group = "com.liferay"
-version = '1.0.3-SNAPSHOT'
+version = '1.0.6-SNAPSHOT'


### PR DESCRIPTION
Version 1.0.5 has been released, so this should be 1.0.6-SNAPSHOT, until release.